### PR TITLE
MIGR-118: bump request timeout to 30s + fix retries

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -45,8 +45,8 @@ module.exports = prototypal({
 
     const options = {
       json: opts.json !== false,
-      timeout: opts.timeout || 1e4,
-      retries: opts.retries,
+      timeout: opts.timeout || 3e4,
+      retries: opts.retries || 0,
       method: requestMethod,
       headers: {
         'user-agent': `cloudflare/${pkg.version} node/${process.versions.node}`,


### PR DESCRIPTION
- Bumping the request timeout to 30s 
- Fixing the way to set the retries option